### PR TITLE
Fix bugs and requests in OTHER-268,271,272,275

### DIFF
--- a/botbot_plugins/plugins/jira.py
+++ b/botbot_plugins/plugins/jira.py
@@ -40,8 +40,8 @@ class Plugin(BasePlugin):
             api_url = urljoin(self.config['jira_url'], self.config['rest_api_suffix'])
             projects = json.loads(self.retrieve('projects'))
 
-            if project.upper() in projects:
-                issue_url = urljoin(api_url, "issue/{}-{}".format(project.upper(), issue))
+            if project in projects:
+                issue_url = urljoin(api_url, "issue/{}-{}".format(project, issue))
                 response = requests.get(issue_url)
 
                 if response.status_code == 200:

--- a/botbot_plugins/plugins/jira.py
+++ b/botbot_plugins/plugins/jira.py
@@ -87,7 +87,9 @@ class Plugin(BasePlugin):
         return "Could not update projects list"
 
     def _get_ignored_bots(self):
-
-        ignored_bots = self.config['ignored_bots'].split(",")
+        try:
+            ignored_bots = self.config['ignored_bots'].split(",")
+        except AttributeError:
+            ignored_bots = []
         ignored_bots = [bot.strip() for bot in ignored_bots]
         return ignored_bots

--- a/botbot_plugins/plugins/jira.py
+++ b/botbot_plugins/plugins/jira.py
@@ -60,7 +60,10 @@ class Plugin(BasePlugin):
                             return_url = urljoin(self.config['jira_url'], "browse/{}".format(name))
                             reply.append("{}: {} {}".format(name, desc, return_url))
 
-            return "\n".join(reply)
+            if line.text.lower().startswith("[off]"):
+                return "[off] {}".format("\n[off] ".join(reply))
+            else:
+                return "\n".join(reply)
 
     @listens_to_mentions(ur'(.*)\bUPDATE:JIRA')
     def update_projects(self, line):


### PR DESCRIPTION
OTHER-275: Add config parameter ignored_bots to ignore parsing other bots.
OTHER-272: Add support for [off] messages.
OTHER-271: Make regex for matching projects more specific.
OTHER-268: Add support for multiple issues in same message.
