### PR TITLE
Fix metabrain not handling whitespace correctly

### DIFF
--- a/botbot_plugins/plugins/metabrain.py
+++ b/botbot_plugins/plugins/metabrain.py
@@ -32,7 +32,7 @@ class Plugin(BasePlugin):
         {{ command_prefix }}braindump
     """
 
-    @listens_to_regex_command("remember", ur"(?P<key>.+?)=\s*(?P<value>.*)")
+    @listens_to_regex_command("remember", ur"(?P<key>.+?)\s*=\s*(?P<value>.*)")
     def remember(self, line, key, value):
         try:
             memory = json.loads(self.retrieve("memory"))

--- a/botbot_plugins/tests/test_metabrain.py
+++ b/botbot_plugins/tests/test_metabrain.py
@@ -44,3 +44,16 @@ def test_remember(app):
     responses = app.respond("!braindump")
     assert responses == ["I have no memory yet, use the recall command to make me remember stuff for you."]
 
+
+def test_whitespace(app):
+    responses = app.respond("!remember a=b")
+    assert responses == ["I will remember \"a\" for you repl_user."]
+
+    responses = app.respond("!remember a =b")
+    assert responses == ["I will remember \"a\" for you repl_user."]
+
+    responses = app.respond("!remember a tree        =       two cakes")
+    assert responses == ["I will remember \"a tree\" for you repl_user."]
+
+    responses = app.respond("!recall a tree")
+    assert responses == ["two cakes"]


### PR DESCRIPTION
Added some extra regex to allow whitespace before the equals sign when using the "remember" command.

I also added a few extra tests to test different whitespace configurations. At this point the tests can probably be cleaned up and further automated to just run through different test phrases but I wouldn't say that's a priority.