### PR TITLE
Github plugin: make '#' symbol mandatory fro pull request lookup

### DIFF
--- a/botbot_plugins/plugins/github.py
+++ b/botbot_plugins/plugins/github.py
@@ -49,7 +49,7 @@ class Plugin(BasePlugin):
         self.store(abbreviation, repo)
         return "Successfully stored the repo {} as {} for Github lookups".format(repo, abbreviation)
 
-    @listens_to_all(ur'(?:.*)\b(?P<repo_abbreviation>[\w\-\_]+)#?(?P<pulls>\d+(?:,\d+)*)\b(?:.*)')
+    @listens_to_all(ur'(?:.*)\b(?P<repo_abbreviation>[\w\-\_]+)#(?P<pulls>\d+(?:,\d+)*)\b(?:.*)')
     def issue_lookup(self, line, repo_abbreviation, pulls):
         """Lookup an specified repo pulls"""
         # pulls can be a list of pulls separated by a comma


### PR DESCRIPTION
This is how we lookup now. ABBR#123
The # symbol was not required in the regex but that does not make sense with the new syntax.