### PR TITLE
Github bot: Use dictionary for default project abbreviations

### DIFF
--- a/botbot_plugins/plugins/github.py
+++ b/botbot_plugins/plugins/github.py
@@ -72,7 +72,7 @@ class Plugin(BasePlugin):
         if not repo:
             if repo_abbreviation in self.project_abbreviations:
                 # Fallback to our hardcoded project_abbreviations
-                repo = project_abbreviations[repo_abbreviation]
+                repo = self.project_abbreviations[repo_abbreviation]
             else:
                 return
         response_list = []

--- a/botbot_plugins/plugins/github.py
+++ b/botbot_plugins/plugins/github.py
@@ -70,7 +70,7 @@ class Plugin(BasePlugin):
         # Check first in our stored values, allows overwriting hardcoded project_abbreviations values
         repo = self.retrieve(repo_abbreviation)
         if not repo:
-            if repo_abbreviation in project_abbreviations:
+            if repo_abbreviation in self.project_abbreviations:
                 # Fallback to our hardcoded project_abbreviations
                 repo = project_abbreviations[repo_abbreviation]
             else:


### PR DESCRIPTION
On bot registration, we do not have access to the underlying app and its store (redis)
Hence #14 was not working once we tried to deploy it.

Instead, let's hardcode* a list of project abbreviations to start with, and allow them to be overwritten by using the redis store.

*Yeah, yeah… we know it's not usually "the proper way" to do anything, but these project keys are very unlikely to change, we allow overrides and this project is only barely maintained, so…